### PR TITLE
Verticle Resize Cursor fix #13 and more.. [dev branch]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `./` from all **symbolic link** cursors
 - Untraced `pkginfo.in` file
 
+### Added
+
+- clickgen **info** in README.md(./README.md)
+
 ## [1.1.5-beta] - 29 July 2020 (Current)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - auto-generated **symlinks** based on input configs
 - `.tar` archive & `directory` as out **package**.
 
-[unreleased]: https://github.com/KaizIqbal/clickgen/compare/1.1.5-beta...master
-[1.1.5-beta]: https://github.com/KaizIqbal/clickgen/compare/1.1.4-alpha...1.1.5-beta
-[1.1.4-beta]: https://github.com/KaizIqbal/clickgen/compare/1.1.3-alpha...1.1.4-beta
-[1.1.3-alpha]: https://github.com/KaizIqbal/clickgen/compare/1.1.2-alpha...1.1.3-alpha
-[1.1.2-alpha]: https://github.com/KaizIqbal/clickgen/compare/1.1.1-alpha...1.1.2-alpha
+[unreleased]: https://github.com/ful1ie5/clickgen/compare/1.1.5-beta...master
+[1.1.5-beta]: https://github.com/ful1ie5/clickgen/compare/1.1.4-alpha...1.1.5-beta
+[1.1.4-beta]: https://github.com/ful1ie5/clickgen/compare/1.1.3-alpha...1.1.4-beta
+[1.1.3-alpha]: https://github.com/ful1ie5/clickgen/compare/1.1.2-alpha...1.1.3-alpha
+[1.1.2-alpha]: https://github.com/ful1ie5/clickgen/compare/1.1.1-alpha...1.1.2-alpha
 [1.1.1-alpha]: https://github.com/kaiziqbal/clickgen/compare/1.1.0-alpha...1.1.1-alpha
 [1.1.0-alpha]: https://github.com/kaiziqbal/clickgen/releases/tag/1.1.0-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+- `vertical resize` wrong implementation fix (KDE Cursor) #13
+- Remove unnecessary cursors from `left_ptr`
+- Remove `./` from all **symbolic link** cursors
+- Untraced `pkginfo.in` file
+
 ## [1.1.5-beta] - 29 July 2020 (Current)
 
-# Changed
+### Changed
 
 - Typo fixed
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <!-- Badges -->
 <p align="center">
   <a href="https://github.com/ful1ie5/clickgen/actions?query=workflow%3Abuild">
-    <img alt="GitHub Action Build" src="https://github.com/ful1ie5/clickgen/workflows/build/badge.svg?branch=master&event=push" />
+    <img alt="GitHub Action Build" src="https://github.com/ful1e5/clickgen/workflows/build/badge.svg" />
   </a>
 
   <a href="https://badge.fury.io/py/clickgen">

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <img src="https://badge.fury.io/py/clickgen.svg" alt="PyPI version" height="20">
   </a>
 
-  <a href="https://www.codefactor.io/repository/github/kaiziqbal/clickgen">
-    <img src="https://www.codefactor.io/repository/github/kaiziqbal/clickgen/badge" alt="CodeFactor" />
+  <a href="https://www.codefactor.io/repository/github/ful1e5/clickgen">
+    <img src="https://www.codefactor.io/repository/github/ful1e5/clickgen/badge" alt="CodeFactor" />
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@
 
 # Clickgen
 
-`clickgen` is API for building **X11** and **Windows** Cursors from `.png` files. **clickgen** is using `anicursorgen` and `xcursorgen` under the hood.
+**clickgen** is _API_ for building **X11** and **Windows** Cursors from `.png` files. clickgen is using `anicursorgen` and `xcursorgen` _under the hood_.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@
 
 # Clickgen
 
-`clickgen` is API for building **X11** and **Windows** Cursors from `.png` files. clickgen is using `anicursorgen` and `xcursorgen` under the hood.
+`clickgen` is API for building **X11** and **Windows** Cursors from `.png` files. **clickgen** is using `anicursorgen` and `xcursorgen` under the hood.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  X11 & Windows Cursor API 👷
+  X11 & Windows Cursor Building API 👷
 </p>
 
 <!-- Badges -->

--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@
     <img src="https://www.codefactor.io/repository/github/ful1e5/clickgen/badge" alt="CodeFactor" />
   </a>
 </p>
+
+---
+
+# Clickgen
+
+`clickgen` is API for building **X11** and **Windows** Cursors from `.png` files. clickgen is using `anicursorgen` and `xcursorgen` under the hood.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 <!-- Badges -->
 <p align="center">
-  <a href="https://github.com/KaizIqbal/clickgen/actions?query=workflow%3Abuild">
-    <img alt="GitHub Action Build" src="https://github.com/KaizIqbal/clickgen/workflows/build/badge.svg?branch=master&event=push" />
+  <a href="https://github.com/ful1ie5/clickgen/actions?query=workflow%3Abuild">
+    <img alt="GitHub Action Build" src="https://github.com/ful1ie5/clickgen/workflows/build/badge.svg?branch=master&event=push" />
   </a>
 
   <a href="https://badge.fury.io/py/clickgen">

--- a/clickgen/linker/__main__.py
+++ b/clickgen/linker/__main__.py
@@ -115,8 +115,6 @@ def link_cursors(directory: Path, win: bool = False) -> None:
                         # links to other if not empty
                         if len(relative) != 0:
                             for link in relative:
-                                src = './' + cursor
-                                dst = './' + link
-                                symlink(src, dst, overwrite=True)
+                                symlink(cursor, link, overwrite=True)
                             print('Symbolic link: %s ==> ' % (cursor),
                                   *relative)

--- a/clickgen/linker/data.json
+++ b/clickgen/linker/data.json
@@ -47,16 +47,7 @@
       "pointer",
       "pointing_hand"
     ],
-    [
-      "left_ptr",
-      "arrow",
-      "default",
-      "top_left_arrow",
-      "size-bdiag",
-      "size-fdiag",
-      "size-hor",
-      "size-ver"
-    ],
+    ["left_ptr", "arrow", "default"],
     [
       "left_ptr_watch",
       "00000000000000020006000e7e9ffc3f",
@@ -100,9 +91,9 @@
       "14fef782d02440884392942c1120523",
       "col-resize",
       "ew-resize",
-      "h_double_arrow",
       "size_hor",
-      "size_ver",
+      "size-hor",
+      "h_double_arrow",
       "split_h"
     ],
     ["sb_left_arrow", "left-arrow"],
@@ -114,6 +105,8 @@
       "2870a09082c103050810ffdffffe0204",
       "double_arrow",
       "ns-resize",
+      "size_ver",
+      "size-ver",
       "row-resize",
       "split_v",
       "v_double_arrow"

--- a/pkginfo.py
+++ b/pkginfo.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-# encoding: utf-8
-
-package_name = 'clickgen'
-package_version = '1.1.2'
-package_description = 'X11 & Windows Cursor API 👷'
-package_author = 'Kaiz Khatri'
-package_author_email = 'kaizmandhu@gmail.com'
-package_status_classifier = 'Development Status :: 3 - Alpha'

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     description=_info['description'],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/KaizIqbal/clickgen',
+    url='https://github.com/ful1ie5/clickgen',
     classifiers=[
         _info['status_classifier'], 'Topic :: System :: Operating System',
         'Programming Language :: Python :: 3', 'Programming Language :: C',


### PR DESCRIPTION
### Changed

- `vertical resize` wrong implementation fix (KDE Cursor) #13
- Remove unnecessary cursors from `left_ptr`
- Remove `./` from all **symbolic link** cursors
- Untraced `pkginfo.in` file

### Added

- clickgen **info** in README.md(./README.md)