### PR TITLE
Patch: Skip Pillow depend (AUR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- Archlinux/Manjaro installation docs
+- CLI usage in [README.md](./README.md)
+
+### Changed
+
+- skip `Pillow` if already installed
+
 ## [1.1.6] - 24 Sept 2020 (Stable)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -32,9 +32,33 @@
 
 ## Install
 
+### using pip
+
 ```bash
 pip3 install clickgen
 ```
+
+### ArchLinux
+
+```bash
+yay -S python-clickgen
+```
+
+### Manjaro
+
+```bash
+pamac build python-clickgen
+```
+
+## CLI
+
+```
+clickgen -h
+```
+
+## PyPi Dependencies
+
+- Pillow/python-pillow
 
 ## Runtime Dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,16 @@ def load_requirements(fname):
     return [str(ir.requirement) for ir in reqs]
 
 
+# Skip `Pillow` if already installed
+try:
+    import PIL
+    INSTALL_REQUIRE = load_requirements('requirements.txt')
+    INSTALL_REQUIRE = list(
+        filter(lambda x: (str(x).find('Pillow')), INSTALL_REQUIRE))
+except ImportError:
+    INSTALL_REQUIRE = load_requirements('requirements.txt')
+
+
 class install(_install):
     def run(self):
         subprocess.call(['make', 'clean', '-C', 'xcursorgen'])
@@ -54,7 +64,7 @@ setup(
     scripts=['scripts/clickgen'],
     keywords=['cursor', 'xcursor', 'windows',
               'linux', 'anicursorgen', 'xcursorgen'],
-    install_requires=load_requirements('requirements.txt'),
+    install_requires=INSTALL_REQUIRE,
     packages=find_namespace_packages(include=['clickgen', 'clickgen.*']),
     include_package_data=True,
     zip_safe=True


### PR DESCRIPTION
### Added

- Archlinux/Manjaro installation docs
- CLI usage in [README.md](./README.md)

### Changed

- skip `Pillow` is already installed
