### PR TITLE
🔧 Development operations with "Makefile"

### DIFF
--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -27,16 +27,14 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Cache pip dependencies
+      - name: Caching pip packages
         uses: actions/cache@v2
+        id: pip-cache # use this to check for `cache-hit` (`steps.pip-cache.outputs.cache-hit != 'true'`)
         with:
-          # This path is specific to Ubuntu
           path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-            ${{ runner.os }}-
 
       - name: Install 'flake8'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+- `Makefile` at the project root added for development operations command
+- Generate `stubfiles` from `make stubgen` command
+- `make clean` command for cleaning clickgen cache
+
 ### Changed
 
+- `CI` pip caching system key changed to `setup.py`
 - Proper typing inheritation inside `clickgen/core.pyi`
 - Linting & Typing fixed in `XCursor` Class `clickgen/builder.py`
+- `xcursorgen/makefile` renamed to `xcursorgen/Makefile`
+- Supress **remove** commands inside `xcursorgen/Makefile`
 
 ## [1.1.9] - 22 Mar 2021
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,24 @@
 clean:
-		@rm -rf .vscode .vim venv .pytest_cache build dist 
-		@cd xcursorgen && make clean
+	rm -rf .vscode .vim venv .pytest_cache build dist clickgen.egg-info .mypy_cache
+	rm -rf clickgen/__pycache__ tests/__pycache__
+	cd xcursorgen && make clean
+	python3 -m pip uninstall -y clickgen
+
+
+MODULES = __init__ builders core db packagers util
+stubgen:
+	rm -rf clickgen/*.pyi
+	$(foreach module,$(MODULES), stubgen "clickgen/$(module).py" -o .;)
+
+test:
+	python3 -m pytest -s -vv --cache-clear
+
+setup_install:
+	python3 setup.py install
+
+pip_install:
+	python3 -m pip install -e .
+
+build: clean
+	python3 setup.py install --user sdist bdist_wheel 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+clean:
+		@rm -rf .vscode .vim venv .pytest_cache build dist 
+		@cd xcursorgen && make clean
+

--- a/xcursorgen/Makefile
+++ b/xcursorgen/Makefile
@@ -10,4 +10,4 @@ xcursorgen.so: xcursorgen.c
 	$(CP) xcursorgen.so $(OUT_DIR)/xcursorgen.so
 
 clean:
-	rm -rf *.o *.so $(OUT_DIR)/xcursorgen.so
+	@rm -rf *.o *.so $(OUT_DIR)/xcursorgen.so


### PR DESCRIPTION
### Added

- `Makefile` at the project root added for development operations command
- Generate `stubfiles` from `make stubgen` command
- `make clean` command for cleaning clickgen cache

### Changed

- `CI` pip caching system key changed to `setup.py`
- Suppress **remove** commands inside `xcursorgen/Makefile`

