### PR TITLE
fix: Resize image to canvas size when re-canvasing

### DIFF
--- a/src/clickgen/parser/png.py
+++ b/src/clickgen/parser/png.py
@@ -82,13 +82,8 @@ class SinglePNGParser(BaseParser):
                     "Input must be 'cursor_size:canvas_size' or an integer."
                 )
 
-            res_img = self._image.resize((size, size), 1)
+            res_img = self._image.resize((canvas_size, canvas_size), 1)
             res_hotspot = self._cal_hotspot(res_img)
-
-            if size != canvas_size:
-                canvas = Image.new("RGBA", (canvas_size, canvas_size), (0, 0, 0, 0))
-                canvas.paste(res_img, (0, 0))
-                res_img = canvas
 
             images.append(
                 CursorImage(


### PR DESCRIPTION
Currently, when using re-canvasing, it just resized the canvas and not the content itself. For example, if you specify `["24:32"]`, it resizes the original image to 24x24, and just pastes it onto a blank 32x32 canvas, meaning there's no visual difference compared to default canvasing.

This fix resizes the original image to the canvas size, and skips the pasting entirely. So `["24:32"]` will result in a correctly proportioned 32x32 image used for a size 24 cursor.